### PR TITLE
Set numId manually and at it to the style id

### DIFF
--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -140,6 +140,16 @@ class ListItem extends AbstractStyle
     }
 
     /**
+     * Set numbering Id, to force list to restart counting. Same num id means same list
+     * @param int
+     */
+    public function setNumId($numInt)
+    {
+        $this->numId = $numInt;
+        $this->getListTypeStyle();
+    }
+
+    /**
      * Get legacy numbering definition
      *
      * @return array
@@ -148,7 +158,12 @@ class ListItem extends AbstractStyle
     private function getListTypeStyle()
     {
         // Check if legacy style already registered in global Style collection
-        $numStyle = "PHPWordList{$this->listType}";
+        $numStyle = "PHPWordList_" . $this->listType;
+        
+        if ($this->numId) {
+            $numStyle .= '_' . $this->numId;
+        }
+        
         if (Style::getStyle($numStyle) !== null) {
             $this->setNumStyle($numStyle);
 


### PR DESCRIPTION
The numId is used to create the numStyleId. This allows restarting list counting. Every ListItem with the same numId belongs to one list.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer check` and no errors were reported
- [ ] The new code is covered by unit tests
- [ ] I have update the documentation to describe the changes
